### PR TITLE
Turn `--omit-header` back into flag

### DIFF
--- a/xtr/src/main.rs
+++ b/xtr/src/main.rs
@@ -131,6 +131,7 @@ fn main() -> Result<(), Error> {
         .arg(
             Arg::new("omit-header")
                 .long("omit-header")
+                .action(ArgAction::SetTrue)
                 .help(&tr!(r#"Don’t write header with ‘msgid ""’ entry"#)),
         )
         .arg(
@@ -261,7 +262,7 @@ fn main() -> Result<(), Error> {
     }
 
     let od = OutputDetails {
-        omit_header: matches.contains_id("omit-header"),
+        omit_header: matches.get_flag("omit-header"),
         copyright_holder: matches.get_one("copyright-holder").cloned(),
         package_name: matches.get_one("package-name").cloned(),
         package_version: matches.get_one("package-version").cloned(),


### PR DESCRIPTION
https://github.com/woboq/tr/commit/ddea8408e322e1b1a644f49ca0a28ddc7653ded3 introduced a regression: `--omit-header` started requiring a value. The regression was released as part of 0.1.7 and 0.1.8. This commit fixes it.

The program only has two other flags, `--help` and `--version`, but those are provided by Clap itself and don't need fixing.