### PR TITLE
Support modules with raw identifiers

### DIFF
--- a/xtr/src/crate_visitor.rs
+++ b/xtr/src/crate_visitor.rs
@@ -21,6 +21,7 @@ use std::mem::swap;
 use std::path::{Path, PathBuf};
 use syn;
 use syn::visit::Visit;
+use syn::ext::IdentExt;
 
 /**
  *  Parse a crate to visit every module. The `visitor` function will be called for every file
@@ -116,7 +117,7 @@ where
             }
         }
 
-        let mod_name = item.ident.to_string();
+        let mod_name = item.ident.unraw().to_string();
         let mut subdir = self.mod_dir.join(mod_name.clone());
         subdir.push("mod.rs");
         if subdir.is_file() {


### PR DESCRIPTION
Example: If processing a module named `r#match` the visitor would look
for a file named `r#match.rs`, instead of the actual `match.rs`. We now
    remove the `r#` prefix to find the correct file.