### PR TITLE
Allow `mod bar;` in `foo.rs` refer to `foo/bar/mod.rs`

### DIFF
--- a/xtr/src/crate_visitor.rs
+++ b/xtr/src/crate_visitor.rs
@@ -143,6 +143,12 @@ where
                     .parse_mod(adjacent)
                     .unwrap_or_else(|err| self.mod_error = Some(err));
             }
+            let adjacent_mod = nested_mod_dir.join(without_suffix).join(&mod_name).join("mod.rs");
+            if adjacent_mod.is_file() {
+                return self
+                    .parse_mod(adjacent_mod)
+                    .unwrap_or_else(|err| self.mod_error = Some(err));
+            }
         }
 
         panic!(


### PR DESCRIPTION
Hello!

I have a project with a few submodules with a slightly inconsistent but correct layout, such as:
```
parent
├── mod.rs  (use foo;)
├── foo.rs  (use bar;)
└── foo
    └── bar
        └── mod.rs
```
Running `xtr` fails with:

`No file with module definition for `mod bar` in file "parent/foo.rs"`

This PR covers this case.