### PR TITLE
Use the name of the crate in `set_translator!` instead of the full module

### DIFF
--- a/tr/src/lib.rs
+++ b/tr/src/lib.rs
@@ -358,10 +358,11 @@ pub mod internal {
     }
 
     pub fn set_translator(module: &'static str, translator: impl Translator + 'static) {
+        let domain = domain_from_module(module);
         TRANSLATORS
             .write()
             .unwrap()
-            .insert(module, Box::new(translator));
+            .insert(domain, Box::new(translator));
     }
 }
 


### PR DESCRIPTION
The macro `set_translator!` was missing the conversion from `module_path` to `domain`.

Most people probably call `set_translator!` from the `main` module, so they are the same and nobody noticed. But I'm calling it from a submodule (actually a generated file by `build.rs`) so the stored translator would never be used.