### PR TITLE
Allow `format_args!` as argument to `tr!`

### DIFF
--- a/tr/src/lib.rs
+++ b/tr/src/lib.rs
@@ -167,12 +167,11 @@ pub mod runtime_format {
         }};
         ($fmt:expr,  $($tail:tt)* ) => {{
             let format_str = $fmt;
-            let fa = $crate::runtime_format::FormatArg {
+            format!("{}", $crate::runtime_format::FormatArg {
                 format_str: AsRef::as_ref(&format_str),
                 //args: &[ $( $crate::runtime_format!(@parse_arg $e) ),* ],
                 args: $crate::runtime_format!(@parse_args [] $($tail)*)
-            };
-            format!("{}", fa)
+            })
         }};
 
         (@parse_args [$($args:tt)*]) => { &[ $( $args ),* ]  };
@@ -545,5 +544,7 @@ mod tests {
             tr!("ctx" => "{0} have one item" | "{0} have {n} items" % 42, "I"),
             "I have 42 items"
         );
+
+        assert_eq!(tr!("{} = {}", 255, format_args!("{:#x}", 255)), "255 = 0xff");
     }
 }


### PR DESCRIPTION
Hi, again!

The `tr!` macro does not accept formatting parameters in its placeholders, that is ok, IMO a translation string is better without those. Then the natural thing to do would be to inject them by writing:
```
tr!("Hello {}", format_args!("{:?}", [1, 2, 3]));
```
Alas, this fails to compile with a cryptic:
```
error[E0716]: temporary value dropped while borrowed
   --> tr/src/lib.rs:527:36
    |
174 |             };
    |              - temporary value is freed at the end of this statement
175 |             format!("{}", fa)
    |                           -- borrow later used here
```

Actually, the doc about [`format_args!`](https://doc.rust-lang.org/stable/std/macro.format_args.html) warns about not storing such a value in local variable.

Naturally, I could just use `format!()`, but `format_args!` is more efficient.

Fortunately, the fix is quite trivial, as the local variable `fa` was there only for code style.