### PR TITLE
Rewrite `FormatArg::Display`

### DIFF
--- a/tr/Cargo.toml
+++ b/tr/Cargo.toml
@@ -18,3 +18,10 @@ default = ["gettext-rs"]
 lazy_static = "1.2"
 gettext-rs = { version = "0.7", optional = true, features = ["gettext-system"] }
 gettext = { version = "0.4", optional = true }
+
+[dev-dependencies]
+criterion = "0.5"
+
+[[bench]]
+name = "my_bench"
+harness = false

--- a/tr/benches/my_bench.rs
+++ b/tr/benches/my_bench.rs
@@ -1,0 +1,38 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use tr::tr;
+
+pub fn short_literal(c: &mut Criterion) {
+    c.bench_function("short_literal", |b| b.iter(|| {
+        tr!("Hello");
+    }));
+}
+
+pub fn long_literal(c: &mut Criterion) {
+    c.bench_function("long_literal", |b| b.iter(|| {
+        tr!("Hello, world! This is a longer sentence but without argument markers. That is all for now, thank you for reading.");
+    }));
+}
+
+pub fn short_argument(c: &mut Criterion) {
+    c.bench_function("short_argument", |b| b.iter(|| {
+        tr!("Hello {}!", black_box("world"));
+    }));
+}
+
+pub fn long_argument(c: &mut Criterion) {
+    c.bench_function("long_argument", |b| b.iter(|| {
+        tr!("Hello {} and {} and {} and {} and {} and {} and {} and finally {}!",
+            black_box("Mercury"),
+            black_box("Venus"),
+            black_box("Earth"),
+            black_box("Mars"),
+            black_box("Jupiter"),
+            black_box("Saturn"),
+            black_box("Uranus"),
+            black_box("Neptune"),
+        );
+    }));
+}
+
+criterion_group!(benches, short_literal, long_literal, short_argument, long_argument);
+criterion_main!(benches);


### PR DESCRIPTION
Currently, the only use of the internal `FormatArg` type is as the single argument to the call `format!("{}", ...)` inside the `runtime_format!` macro.

And the only reason `FormatArg` implements `fmt::Display` is to be able to be used in such a place.

IMO, it would be easier and more efficient just to have a function that builds the final `String` without all the `fmt` mechanisms. Except for the user-provided arguments, of course, that are still `&dyn Display`.

Since now we are writing into a `String` we can pre-allocate its memory, further improving the performance. I'm currently allocating twice the size of the format string, that it looks to me a nice sweet spot.

In this PR I've included two commits: the first one implements that change; the second one adds a benchmark (with crate `criterion`) to confirm the runtime improvements. In my machine I've measured an improvement between 10% and 25%.

I understand that you may prefer the old code over this hypothetical performance improvement. If so, feel free to disregard this PR, no worries. Also should you decide to merge it, you could remove the benchmark, if you think it is unnecessary, it is here mostly for show.

Usually performance in translations is not so important, but I'm using it in a Dear ImGui application, so I'm constantly translating strings, 60 whole UIs per second.

And with this one I reach the end of my PR spree. For now :smile:.